### PR TITLE
No match fix at preg_match_all

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -779,7 +779,7 @@ function rtrim(str, charlist) {
 
 function preg_match_all(regex, haystack) {
     var globalRegex = new RegExp(regex, 'g');
-    var globalMatch = haystack.match(globalRegex);
+    var globalMatch = haystack.match(globalRegex) || [];
     var matchArray = [],
         nonGlobalRegex, nonGlobalMatch;
     for (var i=0; i<globalMatch.length; i++) {


### PR DESCRIPTION
preg_match_all function:If there is no match between the global regex and the haystack the returned value should be an empty array and not null
